### PR TITLE
modificacion catalogo de materiales

### DIFF
--- a/SisUvex/Material/MaterialCatalog/ClsMaterialCatalog.cs
+++ b/SisUvex/Material/MaterialCatalog/ClsMaterialCatalog.cs
@@ -61,8 +61,7 @@ namespace SisUvex.Material.MaterialCatalog
             if (IsAddOrModify)
             {
                 _frmAdd.cboActive.SelectedIndex = 1;
-                _frmAdd.txbId.Text = string.Empty; //SE CAMBIA AL SELECCIONAR UN TIPO DE MATERIAL
-                TxbPrefixApplyEvents();
+                _frmAdd.txbId.Text = string.Empty;
                 InicializateImagesManagers();
             }
             else
@@ -78,8 +77,6 @@ namespace SisUvex.Material.MaterialCatalog
             controlList = new();
 
             controlList.ChangeHeadMessage("Para dar de alta un material debe:\n");
-            controlList.Add(_frmAdd.txbPrefix, "Ingresar un prefijo para él código de material.");
-            controlList.Add(_frmAdd.txbId, "Ingresar el código del material.");
             controlList.Add(_frmAdd.txbIdMaterialType, "Seleccionar un tipo de material.");
             controlList.Add(_frmAdd.txbName, "Ingresar un concepto para el material.");
             controlList.Add(_frmAdd.txbIdUnit, "Seleccionar una unidad.");
@@ -144,8 +141,6 @@ namespace SisUvex.Material.MaterialCatalog
             entity = new();
             entity.GetMaterialCatalog(idAddModify ?? "0");
 
-            _frmAdd.cboMaterialType.Enabled = false;
-            _frmAdd.txbPrefix.Text = entity.idMaterialCatalog?.Substring(0, 2);
             _frmAdd.txbId.Text = entity.idMaterialCatalog;
             _frmAdd.txbName.Text = entity.nameMaterialCatalog;
             _frmAdd.txbQuant.Text = entity.quantity.ToString();
@@ -161,7 +156,6 @@ namespace SisUvex.Material.MaterialCatalog
         private EMaterialCatalog SetMaterialCatalogEntity()
         {
             entity = new();
-            entity.prefix = _frmAdd.txbPrefix.Text;
             entity.idMaterialCatalog = _frmAdd.txbId.Text;
             entity.nameMaterialCatalog = _frmAdd.txbName.Text;
             entity.idMaterialType = _frmAdd.txbIdMaterialType.Text;
@@ -477,80 +471,6 @@ namespace SisUvex.Material.MaterialCatalog
             }
 
             return true;
-        }
-        ////pfefijo
-
-        private void TxbPrefixApplyEvents()
-        {
-            _frmAdd.txbPrefix.KeyPress += txbPrefix_KeyPress;
-            _frmAdd.txbPrefix.TextChanged += txbPrefix_TextChanged;
-            _frmAdd.txbPrefix.KeyDown += txbPrefix_KeyDown;
-        }
-
-        private void txbPrefix_KeyPress(object sender, KeyPressEventArgs e)
-        {
-            // Permitir solo letras y números
-            if (!char.IsLetterOrDigit(e.KeyChar) && !char.IsControl(e.KeyChar))
-            {
-                e.Handled = true;
-                return;
-            }
-
-            // Convertir a mayúsculas automáticamente
-            if (char.IsLetter(e.KeyChar))
-            {
-                e.KeyChar = char.ToUpper(e.KeyChar);
-            }
-
-            // Limitar a 2 caracteres
-            if (_frmAdd.txbPrefix.Text.Length >= 2 && !char.IsControl(e.KeyChar))
-            {
-                e.Handled = true;
-            }
-        }
-
-        private void txbPrefix_TextChanged(object sender, EventArgs e)
-        {
-            // Limpiar el ID si el prefijo no tiene exactamente 2 caracteres
-            if (_frmAdd.txbPrefix.Text.Length != 2)
-            {
-                _frmAdd.txbId.Text = string.Empty;
-                return;
-            }
-
-            // Validar y buscar el siguiente ID solo cuando tenga exactamente 2 caracteres válidos
-            if (IsValidPrefix(_frmAdd.txbPrefix.Text))
-            {
-                _frmAdd.txbId.Text = EMaterialCatalog.GetNextId(_frmAdd.txbPrefix.Text);
-            }
-            else
-            {
-                _frmAdd.txbId.Text = string.Empty;
-            }
-        }
-
-        private bool IsValidPrefix(string prefix)
-        {
-            // Validación adicional si necesitas asegurar que cumple con ciertas reglas
-            return prefix.Length == 2 && prefix.All(c => char.IsLetterOrDigit(c));
-        }
-
-        // Para prevenir el pegado de texto no deseado
-        private void txbPrefix_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Control && e.KeyCode == Keys.V)
-            {
-                e.SuppressKeyPress = true;
-
-                // Pegar solo si el texto es válido
-                var clipboardText = Clipboard.GetText();
-                if (clipboardText.Length >= 2 && clipboardText.All(c => char.IsLetterOrDigit(c)))
-                {
-                    var validText = new string(clipboardText.Where(c => char.IsLetterOrDigit(c)).Take(2).ToArray());
-                    _frmAdd.txbPrefix.Text = validText.ToUpper();
-                    _frmAdd.txbPrefix.SelectionStart = _frmAdd.txbPrefix.Text.Length;
-                }
-            }
         }
     }
 }

--- a/SisUvex/Material/MaterialCatalog/EMaterialCatalog.cs
+++ b/SisUvex/Material/MaterialCatalog/EMaterialCatalog.cs
@@ -21,15 +21,6 @@ namespace SisUvex.Material.MaterialCatalog
         public string? idUnit { get; set; }
         public string? idMaterialType { get; set; }
         public int active { get; set; }
-        public string? prefix { get; set; }
-
-        public static string GetNextId(string prefix)
-        {
-            Dictionary<string, object> parameters = new Dictionary<string, object>();
-            parameters.Add("@prefix", prefix);
-
-            return ClsQuerysDB.GetStringExecuteParameterizedQuery("SELECT CONCAT(@prefix, FORMAT(COALESCE(MAX(RIGHT(id_matCatalog,4)), 0) +1, '0000')) FROM Pack_MaterialCatalog WHERE LEFT(id_matCatalog,2) = @prefix", parameters);
-        }
 
         private void ValidateMaterialCatalog()
         {
@@ -77,7 +68,6 @@ namespace SisUvex.Material.MaterialCatalog
                 sql.OpenConectionWrite();
                 SqlCommand cmd = new SqlCommand("sp_PackMaterialCatalogAdd", sql.cnn);
                 cmd.CommandType = CommandType.StoredProcedure;
-                cmd.Parameters.AddWithValue("@prefix", prefix);
                 cmd.Parameters.AddWithValue("@idMaterialType", ClsValues.IfEmptyToDBNull(idMaterialType));
                 cmd.Parameters.AddWithValue("@idDistributor", ClsValues.IfEmptyToDBNull(idDistributor));
                 cmd.Parameters.AddWithValue("@nameMaterial", nameMaterialCatalog);

--- a/SisUvex/Material/MaterialCatalog/FrmMaterialAdd.Designer.cs
+++ b/SisUvex/Material/MaterialCatalog/FrmMaterialAdd.Designer.cs
@@ -193,7 +193,7 @@
             txbId.Enabled = false;
             txbId.Font = new Font("Segoe UI", 12F, FontStyle.Bold);
             txbId.Location = new Point(112, 121);
-            txbId.MaxLength = 6;
+            txbId.MaxLength = 10;
             txbId.Name = "txbId";
             txbId.Size = new Size(84, 29);
             txbId.TabIndex = 1;
@@ -555,6 +555,7 @@
             txbPrefix.Size = new Size(43, 29);
             txbPrefix.TabIndex = 0;
             txbPrefix.TextAlign = HorizontalAlignment.Center;
+            txbPrefix.Visible = false;
             // 
             // label8
             // 
@@ -566,6 +567,7 @@
             label8.Size = new Size(12, 15);
             label8.TabIndex = 0;
             label8.Text = "*";
+            label8.Visible = false;
             // 
             // label11
             // 
@@ -577,6 +579,7 @@
             label11.TabIndex = 474;
             label11.Text = "Prefijo:";
             label11.TextAlign = ContentAlignment.TopRight;
+            label11.Visible = false;
             // 
             // FrmMaterialAdd
             // 


### PR DESCRIPTION
Modificacion del catalogo de materiales

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the material ID generation/input flow and the parameters passed to `sp_PackMaterialCatalogAdd`, so mismatches with the database stored procedure or expectations around ID formatting could break material creation.
> 
> **Overview**
> Simplifies material creation/editing by **removing the separate `prefix` field workflow**: drops prefix validation/events, stops persisting `prefix` on `EMaterialCatalog`, and removes the `@prefix` parameter and `GetNextId` helper used to precompute the next material ID.
> 
> Updates the add/edit form accordingly by hiding the prefix controls and loosening related validation, and increases `txbId` max length (6→10) while continuing to keep the ID field read-only in the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce0f61fc235fda331a0aa5b71364a86003dcae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->